### PR TITLE
Fix build with rust nightly 2024-01-09

### DIFF
--- a/src/execution_manager/execution_context.rs
+++ b/src/execution_manager/execution_context.rs
@@ -210,7 +210,6 @@ impl ExecutionContext {
             .unwrap()
             .downcast_ref::<PacketsPoolStrategy<E>>()
             .unwrap()
-            .deref()
         {
             PacketsPoolStrategy::None => None,
             PacketsPoolStrategy::Shared(pool) => Some(pool.clone()),

--- a/src/memory_fs/file/writer.rs
+++ b/src/memory_fs/file/writer.rs
@@ -54,7 +54,7 @@ impl FileWriter {
                 match file_read.get_chunk(0).read().deref() {
                     FileChunk::OnDisk { .. } => {
                         if let UnderlyingFile::WriteMode { file, .. } =
-                            file_read.get_underlying_file().deref()
+                            file_read.get_underlying_file()
                         {
                             let mut disk_file_lock = file.1.lock();
                             let position = disk_file_lock.stream_position().unwrap();


### PR DESCRIPTION
Fixes building with rust nightly 2024-01-09 which currently fails with the following error:
```
error: call to `.deref()` on a reference in this situation does nothing
  --> libs-crates/parallel-processor-rs/src/memory_fs/file/writer.rs:57:60
   |
57 | ...                   file_read.get_underlying_file().deref()
   |                                                      ^^^^^^^^ help: remove this redundant call
   |
   = note: the type `UnderlyingFile` does not implement `Deref`, so calling `deref` on `&UnderlyingFile` copies the reference, which does not do anything and can be removed
note: the lint level is defined here
  --> libs-crates/parallel-processor-rs/src/lib.rs:2:36
   |
2  | #![cfg_attr(debug_assertions, deny(warnings))]
   |                                    ^^^^^^^^
   = note: `#[deny(noop_method_call)]` implied by `#[deny(warnings)]`

error: call to `.deref()` on a reference in this situation does nothing
   --> libs-crates/parallel-processor-rs/src/execution_manager/execution_context.rs:212:22
    |
212 |               .unwrap()
    |  ______________________^
213 | |             .deref()
    | |____________________^ help: remove this redundant call
    |
    = note: the type `PacketsPoolStrategy<E>` does not implement `Deref`, so calling `deref` on `&PacketsPoolStrategy<E>` copies the reference, which does not do anything and can be removed

error: could not compile `parallel-processor` (lib) due to 2 previous errors
```

fyi this also breaks ggcat build :wink: 